### PR TITLE
Fix minor YAML warning in Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+---
 language: node_js
 node_js:
   - 10.15.3
@@ -7,11 +8,13 @@ jobs:
     - stage: build
       name: "Build"
       if: branch = master
-      script: yarn
-      script: npx framer-cli build design-system.framerfx 
+      script:
+        - yarn
+        - npx framer-cli build design-system.framerfx
 
     - stage: publish
       name: "Publish"
       if: branch = master
-      script: yarn
-      script: npx framer-cli publish design-system.framerfx --yes
+      script:
+        - yarn
+        - npx framer-cli publish design-system.framerfx --yes

--- a/README.md
+++ b/README.md
@@ -130,14 +130,16 @@ As an example of integrating `framer-cli` with an external CI service, there is 
         - stage: build
           name: "Build"
           if: branch = master
-          script: yarn
-          script: npx framer-cli build <your-project-path.framerfx>
+          script:
+            - yarn
+            - npx framer-cli build <your-project-path.framerfx>
 
         - stage: publish
           name: "Publish"
           if: branch = master
-          script: yarn
-          script: npx framer-cli publish <your-project-path.framerfx> --yes
+          script:
+            - yarn
+            - npx framer-cli publish <your-project-path.framerfx> --yes
    ```
 
 1. Publish a brand new version of your package to the [Framer store](https://store.framer.com) by pushing a commit on the `master` branch.


### PR DESCRIPTION
Fixes the following YAML linting warning:

>key-duplicates: duplication of key "script" in mapping