### PR TITLE
Update github actions yml config

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,13 @@
 ---
-on: push
+on:
+  push:
+    branches: master
 name: Build and publish
 jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-
-      - name: Branch filter
-        uses: actions/bin/filter@master
-        with:
-          args: branch master
 
       - name: Build
         uses: framer/bridge@master


### PR DESCRIPTION
Github Action `actions/bin` has been deprecated / removed.

This causes a 404 error in the current flow. Updated `publish.yml` in favor of an updated filtering syntax.

See links below for more info:

https://github.community/t5/GitHub-Actions/bin-filter-has-been-removed-how-do-we-accomplish-that/td-p/34132

https://help.github.com/en/articles/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet